### PR TITLE
Fix zetamc-tracker-next google sheets sync

### DIFF
--- a/Zetamac-Tracker-Next/manifest.json
+++ b/Zetamac-Tracker-Next/manifest.json
@@ -13,10 +13,13 @@
   },
   "permissions": [
     "storage",
-    "scripting"
+    "scripting",
+    "identity",
+    "alarms"
   ],
   "host_permissions": [
-    "https://arithmetic.zetamac.com/*"
+    "https://arithmetic.zetamac.com/*",
+    "https://www.googleapis.com/*"
   ],
   "content_scripts": [
     {
@@ -26,8 +29,15 @@
       "js": [
         "src/content/content.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_end",
+      "all_frames": true
     }
-  ]
+  ],
+  "oauth2": {
+    "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
+    "scopes": [
+      "https://www.googleapis.com/auth/spreadsheets"
+    ]
+  }
 }
 

--- a/Zetamac-Tracker-Next/src/background/service-worker.js
+++ b/Zetamac-Tracker-Next/src/background/service-worker.js
@@ -3,10 +3,18 @@
 const QUEUE_KEY = 'sheets_upload_queue';
 const AGG_KEY = 'aggregates_v1';
 const RECENT_SESSIONS_KEY = 'recent_sessions';
+const SHEET_ID_KEY = 'sheets_spreadsheet_id';
+const SHEET_TITLE = 'Zetamac Tracker';
+const SESSIONS_SHEET = 'Sessions';
+const PROBLEMS_SHEET = 'Problems';
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 	if (message && message.type === 'SESSION_COMPLETE' && message.data) {
 		handleSessionComplete(message.data);
+	}
+	if (message && message.type === 'MANUAL_SYNC') {
+		processQueue(true).then((ok) => sendResponse({ ok })).catch(err => sendResponse({ ok: false, error: String(err) }));
+		return true; // async response
 	}
 });
 
@@ -21,6 +29,9 @@ async function handleSessionComplete(session) {
 
 	// Queue for Sheets upload
 	await enqueueForSheets(session);
+
+	// Best-effort background processing (non-interactive)
+	processQueue(false).catch(()=>{});
 }
 
 async function getAggregates() {
@@ -95,5 +106,171 @@ async function prependRecentSession(session) {
 	});
 }
 
-// TODO: implement periodic retry via alarms or on startup events
+// ===== Sheets Auth & Sync =====
+let processing = false;
+
+function getAuthToken(interactive) {
+	return new Promise((resolve) => {
+		try {
+			chrome.identity.getAuthToken({ interactive: !!interactive }, (token) => {
+				if (chrome.runtime.lastError) { resolve(null); return; }
+				resolve(token || null);
+			});
+		} catch (e) {
+			resolve(null);
+		}
+	});
+}
+
+async function authedFetch(url, options = {}, interactive = false) {
+	const token = await getAuthToken(interactive);
+	if (!token) throw new Error('No auth token');
+	const headers = Object.assign({}, options.headers || {}, {
+		'Authorization': `Bearer ${token}`,
+		'Content-Type': 'application/json'
+	});
+	const res = await fetch(url, Object.assign({}, options, { headers }));
+	if (!res.ok) {
+		const text = await res.text().catch(()=> '');
+		throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+	}
+	return res;
+}
+
+async function ensureSpreadsheetExists(interactive) {
+	return new Promise((resolve) => {
+		chrome.storage.local.get({ [SHEET_ID_KEY]: null }, async (res) => {
+			let spreadsheetId = res[SHEET_ID_KEY];
+			try {
+				if (!spreadsheetId) {
+					// Create new spreadsheet with two sheets
+					const createBody = {
+						properties: { title: SHEET_TITLE },
+						sheets: [
+							{ properties: { title: SESSIONS_SHEET } },
+							{ properties: { title: PROBLEMS_SHEET } }
+						]
+					};
+					const createRes = await authedFetch('https://sheets.googleapis.com/v4/spreadsheets', {
+						method: 'POST',
+						body: JSON.stringify(createBody)
+					}, interactive);
+					const created = await createRes.json();
+					spreadsheetId = created.spreadsheetId;
+					// Write headers
+					await appendValues(spreadsheetId, `${SESSIONS_SHEET}!A1`, [sessionHeaderRow()], interactive);
+					await appendValues(spreadsheetId, `${PROBLEMS_SHEET}!A1`, [problemHeaderRow()], interactive);
+					chrome.storage.local.set({ [SHEET_ID_KEY]: spreadsheetId }, () => resolve(spreadsheetId));
+				} else {
+					resolve(spreadsheetId);
+				}
+			} catch (e) {
+				resolve(null);
+			}
+		});
+	});
+}
+
+function sessionHeaderRow() {
+	return [
+		'timestamp_end_utc', 'session_id', 'key', 'mode_label', 'duration_s',
+		'score_final', 'problems_captured', 'bucket_size_s', 'score_timeline_10s'
+	];
+}
+
+function problemHeaderRow() {
+	return [
+		'session_id', 'problem_index', 'timestamp_start', 'timestamp_end', 'latency_ms',
+		'problem_text', 'operator', 'operand_a', 'operand_b', 'commutative_key', 'outlier_flag', 'close_reason'
+	];
+}
+
+async function appendValues(spreadsheetId, rangeA1, rows, interactive) {
+	const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(spreadsheetId)}/values/${encodeURIComponent(rangeA1)}:append?valueInputOption=RAW&insertDataOption=INSERT_ROWS`;
+	await authedFetch(url, {
+		method: 'POST',
+		body: JSON.stringify({ values: rows })
+	}, interactive);
+}
+
+async function processQueue(interactive) {
+	if (processing) return true;
+	processing = true;
+	try {
+		const token = await getAuthToken(!!interactive);
+		if (!token) { return false; }
+		const spreadsheetId = await ensureSpreadsheetExists(!!interactive);
+		if (!spreadsheetId) { return false; }
+		// snapshot queue
+		const q = await new Promise(resolve => chrome.storage.local.get({ [QUEUE_KEY]: [] }, res => resolve(res[QUEUE_KEY])));
+		if (!q.length) return true;
+		let remaining = q.slice();
+		let changed = false;
+		for (let i = 0; i < q.length; i++) {
+			const item = q[i];
+			try {
+				const s = item.session || item; // backward safety
+				// Append session row
+				const sessionRow = [
+					new Date().toISOString(),
+					s.session_id,
+					s.key || '',
+					s.mode_label || 'Normal',
+					s.duration_s || 120,
+					s.score_final || 0,
+					s.problems_captured || (s.problems ? s.problems.length : 0),
+					s.bucket_size_s || 10,
+					s.score_timeline_10s || ''
+				];
+				await appendValues(spreadsheetId, `${SESSIONS_SHEET}!A1`, [sessionRow], false);
+				// Append problems rows (if any)
+				const probs = Array.isArray(s.problems) ? s.problems : [];
+				if (probs.length) {
+					const rows = probs.map(p => [
+						s.session_id,
+						p.problem_index,
+						p.timestamp_start,
+						p.timestamp_end,
+						p.latency_ms,
+						p.problem_text,
+						p.operator,
+						p.operand_a,
+						p.operand_b,
+						p.commutative_key,
+						p.outlier_flag ? 'TRUE' : 'FALSE',
+						p.close_reason || ''
+					]);
+					await appendValues(spreadsheetId, `${PROBLEMS_SHEET}!A1`, rows, false);
+				}
+				// remove from remaining
+				remaining = remaining.filter(r => r.id !== item.id);
+				changed = true;
+			} catch (e) {
+				// stop on first failure to avoid rate-limit snowball; keep remaining
+				break;
+			}
+		}
+		if (changed) {
+			await new Promise(resolve => chrome.storage.local.set({ [QUEUE_KEY]: remaining }, () => resolve()));
+		}
+		return remaining.length === 0;
+	} finally {
+		processing = false;
+	}
+}
+
+// Alarms and startup triggers
+chrome.runtime.onInstalled.addListener(() => {
+	try { chrome.alarms.create('sheets-sync', { periodInMinutes: 5 }); } catch (e) {}
+});
+
+chrome.runtime.onStartup.addListener(() => {
+	processQueue(false).catch(()=>{});
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+	if (alarm && alarm.name === 'sheets-sync') {
+		processQueue(false).catch(()=>{});
+	}
+});
 

--- a/Zetamac-Tracker-Next/src/ui/popup.html
+++ b/Zetamac-Tracker-Next/src/ui/popup.html
@@ -31,6 +31,7 @@
     <div class="footer">
       <button id="openDashboard">Dashboard</button>
       <button id="openZetamac">Play</button>
+      <button id="syncNow" title="Sync to Google Sheets">Sync</button>
     </div>
     <div id="syncLine" class="label" style="margin-top:6px;">Last Sync: -</div>
     <script src="popup.js"></script>

--- a/Zetamac-Tracker-Next/src/ui/popup.js
+++ b/Zetamac-Tracker-Next/src/ui/popup.js
@@ -39,5 +39,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 	document.getElementById('openZetamac').addEventListener('click', () => {
 		chrome.tabs.create({ url: 'https://arithmetic.zetamac.com' });
 	});
+
+	const syncBtn = document.getElementById('syncNow');
+	if (syncBtn) {
+		syncBtn.addEventListener('click', () => {
+			syncBtn.disabled = true;
+			syncBtn.textContent = 'Syncing…';
+			chrome.runtime.sendMessage({ type: 'MANUAL_SYNC' }, (res) => {
+				syncBtn.disabled = false;
+				syncBtn.textContent = 'Sync';
+				if (res && res.ok) {
+					const now = new Date().toISOString();
+					document.getElementById('syncLine').textContent = `Last Sync: ${now}`;
+				} else {
+					alert('Sync failed. Try again after authorizing in the browser.');
+				}
+			});
+		});
+	}
 });
 


### PR DESCRIPTION
Add Google Sheets auto-sync for session and problem data to automatically log user activity.

---
<a href="https://cursor.com/background-agent?bcId=bc-82def749-8090-4532-9b68-78071443728b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82def749-8090-4532-9b68-78071443728b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

