### PR TITLE
Retry zetamac tracker sync

### DIFF
--- a/Zetamac-Tracker-Next/manifest.json
+++ b/Zetamac-Tracker-Next/manifest.json
@@ -19,7 +19,8 @@
   ],
   "host_permissions": [
     "https://arithmetic.zetamac.com/*",
-    "https://www.googleapis.com/*"
+    "https://www.googleapis.com/*",
+    "https://sheets.googleapis.com/*"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
Add `sheets.googleapis.com` host permission to resolve sync authorization failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-45149fa0-3799-48fa-a145-de1117cf1981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45149fa0-3799-48fa-a145-de1117cf1981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

